### PR TITLE
Change the order port assigning operations

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const connectDB = require('./server/config/db');
 const { isActiveRoute } = require('./server/helpers/routeHelpers');
 
 const app = express();
-const PORT = 5000 || process.env.PORT;
+const PORT = process.env.PORT || 5000;
   
 // Connect to DB
 connectDB();


### PR DESCRIPTION
change the order port assigning operations. since 5000 is always true, `process.env.PORT` is never accessed 